### PR TITLE
Add eql() method for address equality checks

### DIFF
--- a/any-pointer.zig
+++ b/any-pointer.zig
@@ -59,6 +59,11 @@ pub const SafePointer = struct {
     pub fn isNull(self: SafePointer) bool {
         return self.address == 0;
     }
+
+    /// Returns true if the address of both pointers is the same.
+    pub fn eql(self: SafePointer, other: SafePointer) bool {
+        return self.address == other.address;
+    }
 };
 
 /// A type-erased pointer. Can contain *any* pointer and can be converted back to the original one.
@@ -82,6 +87,11 @@ pub const UnsafePointer = enum(usize) {
     /// Returns true if the pointer is a null pointer
     pub fn isNull(self: UnsafePointer) bool {
         return self == .null_pointer;
+    }
+
+    /// Returns true if the address of both pointers is the same.
+    pub fn eql(self: UnsafePointer, other: UnsafePointer) bool {
+        return self == other;
     }
 };
 

--- a/tests.zig
+++ b/tests.zig
@@ -76,6 +76,38 @@ test "safe null pointer" {
     try std.testing.expectEqual(true, erased.isNull());
 }
 
+test "unsafe address equality" {
+    var i: u32 = 0;
+    var j: u32 = 0;
+
+    const erased = UnsafePointer.make(*u32, &i);
+    const erased_same = UnsafePointer.make(*u32, &i);
+    const erased_other = UnsafePointer.make(*u32, &j);
+    const erased_null = UnsafePointer.null_pointer;
+
+    try std.testing.expectEqual(true, erased.eql(erased_same));
+    try std.testing.expectEqual(false, erased.eql(erased_other));
+
+    try std.testing.expectEqual(true, erased_null.eql(UnsafePointer.null_pointer));
+    try std.testing.expectEqual(false, erased.eql(UnsafePointer.null_pointer));
+}
+
+test "safe address equality" {
+    var i: u32 = 0;
+    var j: u32 = 0;
+
+    const erased = SafePointer.make(*u32, &i);
+    const erased_same = SafePointer.make(*u32, &i);
+    const erased_other = SafePointer.make(*u32, &j);
+    const erased_null = SafePointer.null_pointer;
+
+    try std.testing.expectEqual(true, erased.eql(erased_same));
+    try std.testing.expectEqual(false, erased.eql(erased_other));
+
+    try std.testing.expectEqual(true, erased_null.eql(SafePointer.null_pointer));
+    try std.testing.expectEqual(false, erased.eql(SafePointer.null_pointer));
+}
+
 fn failingTest() void {
     var i: u32 = 0;
 


### PR DESCRIPTION
This is already possible for `UnsafePointer` and `SafePointer` individually, but awkward to do when using `AnyPointer` as the comparison works differently for both types.